### PR TITLE
fix(og-image): replace broken ARC-Hero.webp references with profile.jpeg

### DIFF
--- a/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html
+++ b/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html
@@ -41,7 +41,7 @@
 <meta property="og:title" content="AI Reality Check | Customer Experience with Fine-Tuned Open Source LLMs">
 <meta property="og:description" content="Exploring how fine-tuned open source language models can enhance customer experience and business operations.">
 <meta property="og:url" content="https://airealitycheck.org/articles/cx-and-the-fine-tuned-open-source-llm.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/articles/detection.html
+++ b/career-content/articles/detection.html
@@ -41,7 +41,7 @@
 <meta property="og:title" content="AI Reality Check | AI Content Detection: Challenges and Solutions">
 <meta property="og:description" content="An in-depth analysis of AI content detection tools, their limitations, and best practices for content authenticity.">
 <meta property="og:url" content="https://airealitycheck.org/articles/detection.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/articles/index.html
+++ b/career-content/articles/index.html
@@ -56,7 +56,7 @@
     <meta property="og:description"
         content="In-depth articles about AI technology, implementation strategies, and industry insights.">
     <meta property="og:url" content="https://airealitycheck.org/articles/">
-    <meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+    <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">
 

--- a/career-content/case-studies/index.html
+++ b/career-content/case-studies/index.html
@@ -54,7 +54,7 @@
     <meta property="og:title" content="AI Reality Check | Case Studies">
     <meta property="og:description" content="Real-world AI implementation case studies and success stories.">
     <meta property="og:url" content="https://airealitycheck.org/case-studies/">
-    <meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+    <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">
 

--- a/career-content/case-studies/revenue-cycle-management.html
+++ b/career-content/case-studies/revenue-cycle-management.html
@@ -127,7 +127,7 @@
 <meta property="og:title" content="AI Reality Check | Healthcare Revenue Cycle Management Optimization">
 <meta property="og:description" content="Comprehensive analysis of revenue cycle management transformation in healthcare organizations.">
 <meta property="og:url" content="https://airealitycheck.org/case-studies/revenue-cycle-management.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/index.html
+++ b/career-content/index.html
@@ -44,7 +44,7 @@
     <meta property="og:title" content="AI Reality Check | Career Portfolio">
     <meta property="og:description" content="C. Pete Connor's career portfolio — case studies, articles, portfolio projects, and interactive tools.">
     <meta property="og:url" content="https://airealitycheck.org/career-content/">
-    <meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+    <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">
 

--- a/career-content/portfolio/bpo-wfm-video.html
+++ b/career-content/portfolio/bpo-wfm-video.html
@@ -41,7 +41,7 @@
 <meta property="og:title" content="AI Reality Check | BPO Workforce Management Demo">
 <meta property="og:description" content="Demonstration of Business Process Outsourcing workforce management system capabilities.">
 <meta property="og:url" content="https://airealitycheck.org/portfolio/bpo-wfm-video.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/portfolio/index.html
+++ b/career-content/portfolio/index.html
@@ -45,7 +45,7 @@
     <meta property="og:description"
         content="Portfolio showcasing AI projects, implementations, and technical demonstrations.">
     <meta property="og:url" content="https://airealitycheck.org/portfolio/">
-    <meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+    <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">
 

--- a/career-content/portfolio/oppy-video.html
+++ b/career-content/portfolio/oppy-video.html
@@ -41,7 +41,7 @@
 <meta property="og:title" content="AI Reality Check | Oppy: Dr. Robert J Oppenheimer on AI">
 <meta property="og:description" content="A thought-provoking perspective on artificial intelligence through the lens of historical commentary by Dr. Robert J Oppenheimer.">
 <meta property="og:url" content="https://airealitycheck.org/portfolio/oppy-video.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/portfolio/profile-google-style.html
+++ b/career-content/portfolio/profile-google-style.html
@@ -41,7 +41,7 @@
 <meta property="og:title" content="AI Reality Check | Google Style Profile Interface">
 <meta property="og:description" content="A modern profile interface designed with Google's Material Design principles and clean aesthetics.">
 <meta property="og:url" content="https://airealitycheck.org/portfolio/profile-google-style.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/portfolio/tools.html
+++ b/career-content/portfolio/tools.html
@@ -44,7 +44,7 @@
 <meta property="og:title" content="AI Reality Check | AI Tools & Resources">
 <meta property="og:description" content="A comprehensive collection of AI tools, prompts, and resources for enhancing productivity and creativity.">
 <meta property="og:url" content="https://airealitycheck.org/portfolio/tools.html">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/resources/index.html
+++ b/career-content/resources/index.html
@@ -177,7 +177,7 @@
 <meta property="og:title" content="AI Reality Check | Resources & Tools">
 <meta property="og:description" content="Helpful resources and practical tools to assist with AI implementation.">
 <meta property="og:url" content="https://airealitycheck.org/resources/">
-<meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+<meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
 

--- a/career-content/resources/tools.html
+++ b/career-content/resources/tools.html
@@ -48,7 +48,7 @@
   <meta property="og:title" content="AI Reality Check | Resources & Tools">
   <meta property="og:description" content="Helpful resources and practical tools to assist with AI implementation.">
   <meta property="og:url" content="https://airealitycheck.org/resources/tools.html">
-  <meta property="og:image" content="https://airealitycheck.org/images/hero/ARC-Hero.webp">
+  <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
   <meta property="og:image:alt" content="AI Reality Check banner">
   <meta property="og:locale" content="en_US">
 


### PR DESCRIPTION
Every page in career-content/ pointed og:image to
/images/hero/ARC-Hero.webp, which does not exist on disk. Social link previews were broken on LinkedIn, X, Slack, and Discord for all 13 career pages.

Repointed to /images/profile.jpeg, which exists at 864x1184.