### PR TITLE
fix(canonical): add /career-content/ path segment to canonical and og…

### DIFF
--- a/career-content/articles/counterfactual-reasoning-html.html
+++ b/career-content/articles/counterfactual-reasoning-html.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Unlocking What Didn't Happen: Applying Counterfactual Reasoning to Fix Your Customer and Employee Experience.">
   <title>Unlocking What Didn't Happen | AI Reality Check</title>
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-  <link rel="canonical" href="https://airealitycheck.org/articles/counterfactual-reasoning-html.html">
+  <link rel="canonical" href="https://airealitycheck.org/career-content/articles/counterfactual-reasoning-html.html">
   
   <!-- Resource hints for performance -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html
+++ b/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html
@@ -33,14 +33,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/articles/cx-and-the-fine-tuned-open-source-llm.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | Customer Experience with Fine-Tuned Open Source LLMs">
 <meta property="og:description" content="Exploring how fine-tuned open source language models can enhance customer experience and business operations.">
-<meta property="og:url" content="https://airealitycheck.org/articles/cx-and-the-fine-tuned-open-source-llm.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/articles/detection.html
+++ b/career-content/articles/detection.html
@@ -33,14 +33,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/articles/detection.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/articles/detection.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | AI Content Detection: Challenges and Solutions">
 <meta property="og:description" content="An in-depth analysis of AI content detection tools, their limitations, and best practices for content authenticity.">
-<meta property="og:url" content="https://airealitycheck.org/articles/detection.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/articles/detection.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/articles/index.html
+++ b/career-content/articles/index.html
@@ -47,7 +47,7 @@
         content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
     <!-- Canonical URL (static for SEO reliability) -->
-    <link rel="canonical" href="https://airealitycheck.org/articles/">
+    <link rel="canonical" href="https://airealitycheck.org/career-content/articles/">
 
     <!-- Open Graph / Facebook Meta Tags -->
     <meta property="og:type" content="website">
@@ -55,7 +55,7 @@
     <meta property="og:title" content="AI Reality Check | Articles">
     <meta property="og:description"
         content="In-depth articles about AI technology, implementation strategies, and industry insights.">
-    <meta property="og:url" content="https://airealitycheck.org/articles/">
+    <meta property="og:url" content="https://airealitycheck.org/career-content/articles/">
     <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">

--- a/career-content/case-studies/index.html
+++ b/career-content/case-studies/index.html
@@ -46,14 +46,14 @@
         content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
     <!-- Canonical URL (static for SEO reliability) -->
-    <link rel="canonical" href="https://airealitycheck.org/case-studies/">
+    <link rel="canonical" href="https://airealitycheck.org/career-content/case-studies/">
 
     <!-- Open Graph / Facebook Meta Tags -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="AI Reality Check">
     <meta property="og:title" content="AI Reality Check | Case Studies">
     <meta property="og:description" content="Real-world AI implementation case studies and success stories.">
-    <meta property="og:url" content="https://airealitycheck.org/case-studies/">
+    <meta property="og:url" content="https://airealitycheck.org/career-content/case-studies/">
     <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">

--- a/career-content/case-studies/revenue-cycle-management.html
+++ b/career-content/case-studies/revenue-cycle-management.html
@@ -119,14 +119,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/case-studies/revenue-cycle-management.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/case-studies/revenue-cycle-management.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | Healthcare Revenue Cycle Management Optimization">
 <meta property="og:description" content="Comprehensive analysis of revenue cycle management transformation in healthcare organizations.">
-<meta property="og:url" content="https://airealitycheck.org/case-studies/revenue-cycle-management.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/case-studies/revenue-cycle-management.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/portfolio/bpo-wfm-video.html
+++ b/career-content/portfolio/bpo-wfm-video.html
@@ -33,14 +33,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/portfolio/bpo-wfm-video.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/portfolio/bpo-wfm-video.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | BPO Workforce Management Demo">
 <meta property="og:description" content="Demonstration of Business Process Outsourcing workforce management system capabilities.">
-<meta property="og:url" content="https://airealitycheck.org/portfolio/bpo-wfm-video.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/bpo-wfm-video.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/portfolio/index.html
+++ b/career-content/portfolio/index.html
@@ -36,7 +36,7 @@
         content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
     <!-- Canonical URL (static for SEO reliability) -->
-    <link rel="canonical" href="https://airealitycheck.org/portfolio/">
+    <link rel="canonical" href="https://airealitycheck.org/career-content/portfolio/">
 
     <!-- Open Graph / Facebook Meta Tags -->
     <meta property="og:type" content="website">
@@ -44,7 +44,7 @@
     <meta property="og:title" content="AI Reality Check | Portfolio">
     <meta property="og:description"
         content="Portfolio showcasing AI projects, implementations, and technical demonstrations.">
-    <meta property="og:url" content="https://airealitycheck.org/portfolio/">
+    <meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/">
     <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
     <meta property="og:image:alt" content="AI Reality Check banner">
     <meta property="og:locale" content="en_US">

--- a/career-content/portfolio/oppy-video.html
+++ b/career-content/portfolio/oppy-video.html
@@ -33,14 +33,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/portfolio/oppy-video.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/portfolio/oppy-video.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | Oppy: Dr. Robert J Oppenheimer on AI">
 <meta property="og:description" content="A thought-provoking perspective on artificial intelligence through the lens of historical commentary by Dr. Robert J Oppenheimer.">
-<meta property="og:url" content="https://airealitycheck.org/portfolio/oppy-video.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/oppy-video.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/portfolio/profile-google-style.html
+++ b/career-content/portfolio/profile-google-style.html
@@ -33,14 +33,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/portfolio/profile-google-style.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/portfolio/profile-google-style.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | Google Style Profile Interface">
 <meta property="og:description" content="A modern profile interface designed with Google's Material Design principles and clean aesthetics.">
-<meta property="og:url" content="https://airealitycheck.org/portfolio/profile-google-style.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/profile-google-style.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">
@@ -89,7 +89,7 @@
   
   <meta property="og:title" content="C. Pete Connor – Professional CX Profile">
   <meta property="og:description" content="A dynamic portfolio of CX-driven accomplishments with strategic, metrics-driven outcomes.">
-  <meta property="og:url" content="https://airealitycheck.org/portfolio/profile-google-style.html">
+  <meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/profile-google-style.html">
   
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/career-content/portfolio/tools.html
+++ b/career-content/portfolio/tools.html
@@ -36,14 +36,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/portfolio/tools.html">
+<link rel="canonical" href="https://airealitycheck.org/career-content/portfolio/tools.html">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | AI Tools & Resources">
 <meta property="og:description" content="A comprehensive collection of AI tools, prompts, and resources for enhancing productivity and creativity.">
-<meta property="og:url" content="https://airealitycheck.org/portfolio/tools.html">
+<meta property="og:url" content="https://airealitycheck.org/career-content/portfolio/tools.html">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/resources/index.html
+++ b/career-content/resources/index.html
@@ -169,14 +169,14 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
 <!-- Canonical URL (static for SEO reliability) -->
-<link rel="canonical" href="https://airealitycheck.org/resources/">
+<link rel="canonical" href="https://airealitycheck.org/career-content/resources/">
 
 <!-- Open Graph / Facebook Meta Tags -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="AI Reality Check">
 <meta property="og:title" content="AI Reality Check | Resources & Tools">
 <meta property="og:description" content="Helpful resources and practical tools to assist with AI implementation.">
-<meta property="og:url" content="https://airealitycheck.org/resources/">
+<meta property="og:url" content="https://airealitycheck.org/career-content/resources/">
 <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
 <meta property="og:image:alt" content="AI Reality Check banner">
 <meta property="og:locale" content="en_US">

--- a/career-content/resources/tools.html
+++ b/career-content/resources/tools.html
@@ -40,14 +40,14 @@
     content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com; connect-src 'self'; object-src 'none'">
 
   <!-- Canonical URL (static for SEO reliability) -->
-  <link rel="canonical" href="https://airealitycheck.org/resources/tools.html">
+  <link rel="canonical" href="https://airealitycheck.org/career-content/resources/tools.html">
 
   <!-- Open Graph / Facebook Meta Tags -->
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="AI Reality Check">
   <meta property="og:title" content="AI Reality Check | Resources & Tools">
   <meta property="og:description" content="Helpful resources and practical tools to assist with AI implementation.">
-  <meta property="og:url" content="https://airealitycheck.org/resources/tools.html">
+  <meta property="og:url" content="https://airealitycheck.org/career-content/resources/tools.html">
   <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
   <meta property="og:image:alt" content="AI Reality Check banner">
   <meta property="og:locale" content="en_US">


### PR DESCRIPTION
…:url tags

13 career-content pages had canonical and og:url tags missing the /career-content/ URL prefix, pointing search engines and social scrapers to URLs that 404 against the live site.

Affected: 13 canonical tags + 14 og:url tags (one duplicate on profile-google-style.html, both fixed; will dedupe in a later PR).

Body content nav links also have this problem but are out of scope for this PR — to be addressed separately.