### PR TITLE
chore(perf): remove placeholder JS stubs and their script tags

### DIFF
--- a/career-content/articles/index.html
+++ b/career-content/articles/index.html
@@ -263,7 +263,6 @@
     </footer>
 
     <script src="../js/main.min.js"></script>
-    <script src="../js/scroll-animations.js"></script>
 
 </body>
 

--- a/career-content/case-studies/index.html
+++ b/career-content/case-studies/index.html
@@ -286,7 +286,6 @@
     </footer>
 
     <script src="../js/main.min.js"></script>
-    <script src="../js/scroll-animations.js"></script>
 
 </body>
 

--- a/career-content/js/scroll-animations.js
+++ b/career-content/js/scroll-animations.js
@@ -1,2 +1,0 @@
-/* AI Reality Check — Scroll Animations
-   Placeholder for scroll-triggered animation functionality. */

--- a/career-content/js/video-player.js
+++ b/career-content/js/video-player.js
@@ -1,2 +1,0 @@
-/* AI Reality Check — Video Player
-   Placeholder for video player functionality. */

--- a/career-content/portfolio/bpo-wfm-video.html
+++ b/career-content/portfolio/bpo-wfm-video.html
@@ -385,7 +385,6 @@
     </div>
 </footer>
 
-    <script src="../js/video-player.js"></script>
     <script src="../js/main.min.js"></script>
     
     

--- a/career-content/portfolio/index.html
+++ b/career-content/portfolio/index.html
@@ -250,7 +250,6 @@
     </footer>
 
     <script src="../js/main.min.js"></script>
-    <script src="../js/scroll-animations.js"></script>
 
     <!-- Load components -->
 

--- a/career-content/portfolio/oppy-video.html
+++ b/career-content/portfolio/oppy-video.html
@@ -334,7 +334,6 @@
     </div>
 </footer>
 
-    <script src="../js/video-player.js"></script>
     <script src="../js/main.min.js"></script>
     
     


### PR DESCRIPTION
scroll-animations.js and video-player.js were 2-line comment files with no executable code, loaded on 5 career-content pages. Each script tag added an HTTP round-trip for nothing.

Removed both files plus the 5 referencing script tags. Net result: 10 fewer requests across the affected pages, cleaner network panel during demos, no functional change.