### PR TITLE
chore(seo): refresh sitemap lastmod to 2026-04-26 across 25 URLs

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://airealitycheck.org/</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -10,31 +10,31 @@
   <!-- Articles -->
   <url>
     <loc>https://airealitycheck.org/career-content/articles/index.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/articles/automation-strategy-article.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/articles/counterfactual-reasoning-html.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/articles/cx-and-the-fine-tuned-open-source-llm.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/articles/detection.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -42,37 +42,37 @@
   <!-- Case Studies -->
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/index.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/contact-center-analytics-AI-Executive-Overview.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/hr-predictive-model.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/linkedin-visibility-google-style.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/ml-bpo-turnover-wfm.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/case-studies/revenue-cycle-management.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -80,49 +80,49 @@
   <!-- Portfolio -->
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/index.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/bpo-wfm-video.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/cxer-ml-ai-triage-kit.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/oppy-video.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/profile-google-style.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/social-media-analytics.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/tiktok-dashboard-google-style-1.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/portfolio/tools.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -130,31 +130,31 @@
   <!-- Resources -->
   <url>
     <loc>https://airealitycheck.org/career-content/resources/index.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/resources/ai-readiness-assessment.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/resources/prompt-workspace.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/resources/roi-calculator.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://airealitycheck.org/career-content/resources/tools.html</loc>
-    <lastmod>2026-02-19</lastmod>
+    <lastmod>2026-04-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
All 25 sitemap entries showed lastmod=2026-02-19, signaling to search engines that the sitemap was unmaintained. Updated to today's date to encourage faster recrawl of recent canonical and og:image fixes.