### PR TITLE
fix(theme): align career-content hub to use 'arc-theme' localStorage key

### DIFF
--- a/career-content/index.html
+++ b/career-content/index.html
@@ -11,7 +11,7 @@
 
     <script>
         (function () {
-            const savedTheme = localStorage.getItem('theme') || 'auto';
+            const savedTheme = localStorage.getItem('arc-theme') || 'auto';
             document.documentElement.className = 'theme-' + savedTheme;
         })();
     </script>


### PR DESCRIPTION
career-content/index.html line 14 read localStorage.getItem('theme') but loader.min.js and main.min.js read/write 'arc-theme'. The key mismatch meant the theme toggle never persisted across visits to the hub page, causing brief theme flicker on every load.

Single-character key change resolves the mismatch. The inline IIFE remains as intentional FOUC-prevention before loader.min.js loads.