### PR TITLE
fix(seo): add full SEO meta block to prompt-workspace.html

### DIFF
--- a/career-content/resources/prompt-workspace.html
+++ b/career-content/resources/prompt-workspace.html
@@ -4,6 +4,28 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prompt Engineering Workspace | AI Reality Check</title>
+  <meta name="description" content="Interactive prompt engineering workspace for crafting, testing, and refining LLM prompts. Save templates, compare outputs, and iterate on AI workflows.">
+  <meta name="author" content="C. Pete Connor">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://airealitycheck.org/career-content/resources/prompt-workspace.html">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="AI Reality Check">
+  <meta property="og:title" content="AI Reality Check | Prompt Engineering Workspace">
+  <meta property="og:description" content="Interactive prompt engineering workspace for crafting, testing, and refining LLM prompts. Save templates, compare outputs, and iterate on AI workflows.">
+  <meta property="og:url" content="https://airealitycheck.org/career-content/resources/prompt-workspace.html">
+  <meta property="og:image" content="https://airealitycheck.org/images/profile.jpeg">
+  <meta property="og:image:alt" content="AI Reality Check banner">
+  <meta property="og:locale" content="en_US">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="AI Reality Check | Prompt Engineering Workspace">
+  <meta name="twitter:description" content="Interactive prompt engineering workspace for crafting, testing, and refining LLM prompts. Save templates, compare outputs, and iterate on AI workflows.">
+  <meta name="twitter:image" content="https://airealitycheck.org/images/profile.jpeg">
+
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
prompt-workspace.html had only viewport and charset meta tags — no description, no canonical, no Open Graph, no Twitter Card. As a result, search results showed no snippet and social shares had no preview, despite the page being a public resource.

Added description, author, canonical, full OG block, and Twitter summary_large_image card. Image points to profile.jpeg pending the dedicated 1200x630 OG card from a later PR.